### PR TITLE
Process JavaDoc for unused imports check

### DIFF
--- a/src/main/resources/jboss-as-checkstyle/checkstyle.xml
+++ b/src/main/resources/jboss-as-checkstyle/checkstyle.xml
@@ -24,7 +24,9 @@
         </module>
         <module name="RedundantImport"/>
 
-        <module name="UnusedImports" />
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
 
         <module name="IllegalImport">
             <property name="illegalPkgs" value="junit.framework"/>


### PR DESCRIPTION
Requires checkstyle 6.0 or later, which must be added in as a dependency to the checkstyle plugin either in parent or in the target project.
