### PR TITLE
Add suppressions for translation files

### DIFF
--- a/src/main/resources/wildfly-checkstyle/checkstyle.xml
+++ b/src/main/resources/wildfly-checkstyle/checkstyle.xml
@@ -63,5 +63,9 @@
 
     </module>
 
+    <module name="SuppressionFilter">
+        <property name="file" value="/wildfly-checkstyle/suppressions.xml" />
+    </module>
+
 </module>
 

--- a/src/main/resources/wildfly-checkstyle/suppressions.xml
+++ b/src/main/resources/wildfly-checkstyle/suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <!-- Ignore files pulled down from translations services -->
+    <suppress files=".*\.i18n_.*\.properties" checks=".*"/>
+    <suppress files="LocalDescriptions_.*\.properties" checks=".*"/>
+</suppressions>


### PR DESCRIPTION
This allows files pulled down from Zanata to be ignored. The main issue seems to be trailing spaces so if we're more comfortable we could just ignore specific checks.
