### PR TITLE
WFLY-9601 upgrade version of checkstyle to latest

### DIFF
--- a/src/main/resources/wildfly-checkstyle/checkstyle.xml
+++ b/src/main/resources/wildfly-checkstyle/checkstyle.xml
@@ -49,7 +49,6 @@
         <!-- Disabled until http://sourceforge.net/tracker/?func=detail&aid=2843447&group_id=29721&atid=397078 is fixed-->
         <!--<module name="DoubleCheckedLocking"/>-->
         <module name="EmptyStatement"/>
-        <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
         <!-- removed in checkstyle 6.2, see https://github.com/checkstyle/checkstyle/issues/473 -->
         <!--module name="RedundantThrows">

--- a/src/main/resources/wildfly-checkstyle/checkstyle.xml
+++ b/src/main/resources/wildfly-checkstyle/checkstyle.xml
@@ -34,7 +34,10 @@
 
         <!-- Modifier Checks                                    -->
         <module name="ModifierOrder"/>
-        <module name="RedundantModifier"/>
+        <!-- Too many errors reported since Checkstyle upgrade to > 6.2 -->
+        <module name="RedundantModifier">
+          <property name="tokens" value="ANNOTATION_FIELD_DEF, RESOURCE"/>
+      </module>
 
         <!-- Checks for blocks. You know, those {}'s         -->
         <module name="LeftCurly">


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-13800
Upstream Issue: https://issues.jboss.org/browse/WFLY-9601
No Upstream PR required

As discussed on [PR10696](https://github.com/wildfly/wildfly/pull/10696), the rule RedundantModifier has been disabled.